### PR TITLE
Fix namespace to make autoloading work

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	},
 	"autoload": {
 		"psr-4": {
-			"Geodesy\\": "src/"
+			"Geodesy\\": "src/Geodesy/"
 		}
 	},
 	"autoload-dev": {


### PR DESCRIPTION
Hello! 

I was using this as composer package, but I kept getting the error: `class Geodesy\Location\LatLong was not found`. I started looking for it but found that your `src` folder did contain a `Geodesy` folder, even though your psr-4 namespace declaration in `composer.json` pointed to the `src` folder. Therefore classes could not be found. Including the `Geodesy` folder in the namespace declaration fixed this issue. 